### PR TITLE
[fix] mgrs_id parsing error when UTM code is not two digits i.e. 4

### DIFF
--- a/get_sentinel2.py
+++ b/get_sentinel2.py
@@ -64,7 +64,7 @@ def aws_url_from_metadata_dict_backend(d, api='devseed'):
     Build the AWS url of a Sentinel-2 image from it's metadata.
     """
     date, mgrs_id = date_and_mgrs_id_from_metadata_dict(d, api)
-    utm_code, lat_band, sqid = mgrs_id[:2], mgrs_id[2], mgrs_id[3:]
+    _, utm_code, lat_band, sqid,_ = re.split('(\d+)([a-zA-Z])([a-zA-Z]+)',mgrs_id)
     return '{}/tiles/{}/{}/{}/{}/{}/{}/0/'.format(aws_url, utm_code, lat_band,
                                                   sqid, date.year, date.month,
                                                   date.day)


### PR DESCRIPTION
The format of mgrs_id assumed 2 digits for the utm_code.
But this fails in Honolulu for which we have: 4QFJ

The fix uses a regex to split the field, probably there's a better solution. 
In addition, the same error may be in other places too. 